### PR TITLE
watcher: always listen for change events

### DIFF
--- a/bin/cssnext.js
+++ b/bin/cssnext.js
@@ -178,7 +178,7 @@ if (watcher) {
       log(colors.cyan("Watching"), input)
     }
   })
-  
+
   watcher.on("change", transform)
 }
 

--- a/bin/cssnext.js
+++ b/bin/cssnext.js
@@ -177,9 +177,9 @@ if (watcher) {
     if (verbose) {
       log(colors.cyan("Watching"), input)
     }
-
-    watcher.on("change", transform)
   })
+  
+  watcher.on("change", transform)
 }
 
 /**


### PR DESCRIPTION
watcher.on("ready") doesn't fire for multiple imports (why? I don't know!), we want to listen to changes regardless.

should fix #123