### PR TITLE
Fixed undefined when printing bug report URL.

### DIFF
--- a/bin/cssnext.js
+++ b/bin/cssnext.js
@@ -177,7 +177,7 @@ function transform() {
         console.error()
       }
       console.error("If this error looks like a bug, please report it here:")
-      console.error(color.grey("❯ ") + pkg.bugs.url.cyan)
+      console.error(color.grey("❯ ") + color.cyan(pkg.bugs.url))
       console.error()
       if (!config.watch) {
         exit(2)


### PR DESCRIPTION
Misuse of chalk was not printing bug report URL as it should have been. `undefined` was printed instead.