### PR TITLE
Fixed width overflow on small device

### DIFF
--- a/docs/src/index.css
+++ b/docs/src/index.css
@@ -101,7 +101,7 @@ h6 {
  */
 
 .r-Grid {
-  width: auto;
+  width: 100%;
   margin: 0 auto;
   padding: 0 1rem;
 }


### PR DESCRIPTION
On Firefox and Chrome (android) there is an overflow because of  `width:auto`, even if it's ok on iOS

before / after

![cssnext](https://cloud.githubusercontent.com/assets/1997108/8228416/bd75ec6c-15ae-11e5-86ae-6cac868c7a2a.png)
