### PR TITLE
Bump cssnano to v2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chalk": "^1.0.0",
     "chokidar": "^1.0.0",
     "commander": "^2.3.0",
-    "cssnano": "^1.3.0",
+    "cssnano": "^2.0.1",
     "exit": "^0.1.2",
     "pixrem": "^1.1.0",
     "pleeease-filters": "^1.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -143,9 +143,6 @@ function cssnext(string, options) {
           ? options.compress
           : {}
         ),
-        // forced calc options to false
-        // since we already used it
-        calc: false,
       })
     )
   }


### PR DESCRIPTION
cssnano 2 features built in 'quiet' removal of plugins, so disabling calc isn't necessary now.