### PR TITLE
Fix bug #200: css.walkRules is not a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cssnano": "^2.0.1",
     "exit": "^0.1.2",
     "mkdirp": "^0.5.1",
-    "pixrem": "^1.1.0",
+    "pixrem": "1.3.1",
     "pleeease-filters": "^1.0.0",
     "postcss": "^4.0.2",
     "postcss-calc": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "cssrecipes-grid": "^0.4.0",
     "cssrecipes-utils": "^0.5.0",
     "cssrecipes-vertical-rhythm": "^0.6.0",
-    "eslint": "^1.0.0-rc-1",
+    "eslint": "~1.0.0-rc-1",
     "eslint-loader": "^0.14.2",
     "eslint-plugin-react": "^3.0.0",
     "extract-text-webpack-plugin": "^0.8.0",


### PR DESCRIPTION
I commit 2 changes:

1. to fix npm install with the problem of dependencies `npm ERR! peerinvalid The package eslint does not satisfy its siblings' peerDependencies requirements! npm ERR! peerinvalid Peer eslint-loader@0.14.2 wants eslint@0.21 - 0.24 || ~1.0.0-rc-0`
2. to fix the #200 with invalid version upgrade of node-pixrem

BTW, npm test is freezed on 51:
```
Hash: 6f7d6564bb5071230c2c
Version: webpack 1.11.0
Time: 8967ms
     Asset     Size  Chunks             Chunk Names
cssnext.js  9.53 MB       0  [emitted]  main
    + 1463 hidden modules

> cssnext@1.8.3 tape /home/enguerran/Development/cssnext
> tape 'dist/__tests__/*.js'

TAP version 13
# cssnext API
ok 1 should return a string
ok 2 should return a string, even if the given string is empty
ok 3 simple example with multiples features should work with cssnext API
ok 4 should return a postcss instance
ok 5 simple example with multiples features should work with postcss API
ok 6 doesn't mutate options object
# use case: color plugins together
ok 7 all color plugins should works together
# use case: use plugin options
ok 8 should be able to pass options to plugins
# cli
ok 9 should return an error when input file is unreadable
ok 10 should show that the input file is not found
ok 11 should not modify input of 'color hex alpha' fixture if all features are disabled
ok 12 should not modify input of 'pseudo class matches' fixture if all features are disabled
ok 13 should not modify input of 'color gray' fixture if all features are disabled
ok 14 should not modify input of 'font variant' fixture if all features are disabled
ok 15 should throw an error
ok 16 should output a readable error
ok 17 should show the url where to report bugs
ok 18 should not modify input of 'color rebeccapurple' fixture if all features are disabled
ok 19 should not modify input of 'color hwb' fixture if all features are disabled
ok 20 should not modify input of 'media queries range' fixture if all features are disabled
ok 21 should not modify input of 'rem' fixture if all features are disabled
ok 22 should rebase url
ok 23 should not modify input of 'color rgba' fixture if all features are disabled
ok 24 should not modify input of 'pseudo elements' fixture if all features are disabled
ok 25 should not modify input of 'custom selectors' fixture if all features are disabled
ok 26 should not modify input of 'pseudo class any link' fixture if all features are disabled
ok 27 should not modify input of 'autoprefixer' fixture if all features are disabled
ok 28 should not modify input of 'custom media' fixture if all features are disabled
ok 29 should not modify input of 'custom properties' fixture if all features are disabled
ok 30 should not modify input of 'calc' fixture if all features are disabled
ok 31 should return an error when <input> or <output> are missing when `--watch` option passed
ok 32 should show an explanation when <input> or <output> are missing when `--watch` option passed
ok 33 should read config file on --config
ok 34 should not modify input of 'filter' fixture if all features are disabled
ok 35 should not modify input of 'color function' fixture if all features are disabled
ok 36 should return an error when <output> is missing when `--watch`option passed
ok 37 should show an explanation when <output> is missing when `--watch` option passed
ok 38 should log on --verbose
ok 39 should not modify input of 'pseudo class not' fixture if all features are disabled
ok 40 should read from stdin and write to stdout
ok 41 should have a --browsers option
ok 42 should read from a file and write to a file
ok 43 should not adjust url on --no-url
ok 44 should read from a file and write to stdout
ok 45 should add sourcemap on --sourcemap
ok 46 should not import on --no-import
not ok 47 should compress on --compress
  ---
    operator: equal
    expected: |-
      '/*! sha */body{color:red}'
    actual: |-
      '/*! sha */\n/* blah */\nbody {\n    color  : red;\n}'
    at: maybeClose (internal/child_process.js:764:16)
  ...
# cli/watcher
ok 48 should output error messages when `--watch` option passed
ok 49 should update the file
ok 50 should update the file, again
ok 51 should not modify a file if a previously imported file is modified
```